### PR TITLE
WIP: Try and handle disconnection events

### DIFF
--- a/safe_core/src/connection_manager.rs
+++ b/safe_core/src/connection_manager.rs
@@ -100,7 +100,8 @@ impl Inner {
             let _ = value.insert(fry!(ConnectionGroup::new(
                 self.config.clone(),
                 full_id,
-                connected_tx
+                connected_tx,
+                self.net_tx.clone(),
             )));
             Box::new(
                 connected_rx


### PR DESCRIPTION
When there is a loss of  internet connection at the client, the quic-p2p connection between the client and an elder is lost. When the client sends the next message quic-p2p will identify the missing connection and automatically call `quic_p2p::connect_to()`.

In this case the internet connection at the elder is still available so when calling connect_to() again, the following error is returned:
```
Peer .... has a connection to us but we couldn't connect to it. All connections to this peer will now be severed. 
```
This PR manually calls `disconnect_from(peer)` whenever the network connection is lost so that the connection is severed before attempting to connect to it again.