### PR TITLE
chore(deps): update ci dependency graph generator script

### DIFF
--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -5,7 +5,10 @@ set -e -x
 rm -rf images
 mkdir images
 
+# Generate Cargo.lock, must be present and up to date for cargo-deps to run
+cargo generate-lockfile
+
 cargo install cargo-deps
 
-cargo deps --all-deps --include-orphans --filter sn_client self_encryption qp2p sn_data_types sn_transfers xor_name | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/sn_client-sn-dependencies.png
+cargo deps --all-deps --include-orphans --filter sn_client self_encryption qp2p sn_data_types sn_transfers xor_name sn_messaging | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/sn_client-sn-dependencies.png
 cargo deps | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/sn_client-all-dependencies.png


### PR DESCRIPTION
Updated to reflect current sn_client internal maidsafe repository dependencies.
Also added a step to the script to generate a Cargo.lock - since this was recently removed from the repo cargo-deps has not been able to run.