### PR TITLE
fix: transfer listener cleanup should happen only once

### DIFF
--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -854,7 +854,7 @@ impl Session {
         let _ = tokio::spawn(async move {
             while let Some((src, message)) = incoming_messages.next().await {
                 let message_type = WireMsg::deserialize(message)?;
-                warn!("Message received at listener from {:?}", &src);
+                trace!("Message received at listener from {:?}", &src);
                 let session_clone = session.clone();
                 session = match message_type {
                     MessageType::SectionInfo(msg) => {


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
