### PR TITLE
Feat resend recent messages on infra updates

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -231,7 +231,7 @@ impl Client {
 
         let message = self.create_query_message(query).await?;
 
-        self.session.send_query(&message).await
+        self.session.send_and_listen_for_response(&message).await
     }
 
     // Build and sign Cmd Message Envelope
@@ -275,7 +275,10 @@ impl Client {
         };
         let message = self.create_cmd_message(msg_contents).await?;
 
-        let _ = self.session.send_cmd(&message).await?;
+        let _ = self
+            .session
+            .send_without_listening_for_response(&message)
+            .await?;
 
         self.apply_write_payment_to_local_actor(payment_proof).await
     }

--- a/src/client/sequence_apis.rs
+++ b/src/client/sequence_apis.rs
@@ -222,7 +222,10 @@ impl Client {
         };
         let message = self.create_cmd_message(msg_contents).await?;
 
-        let _ = self.session.send_cmd(&message).await?;
+        let _ = self
+            .session
+            .send_without_listening_for_response(&message)
+            .await?;
 
         self.apply_write_payment_to_local_actor(payment_proof).await
     }

--- a/src/client/transfer_actor/balance_management.rs
+++ b/src/client/transfer_actor/balance_management.rs
@@ -82,7 +82,7 @@ impl Client {
         let msg_contents = Query::Transfer(TransferQuery::GetBalance(public_key));
 
         let message = self.create_query_message(msg_contents).await?;
-        let res = self.session.send_query(&message).await?;
+        let res = self.session.send_and_listen_for_response(&message).await?;
 
         match res {
             QueryResponse::GetBalance(balance) => balance.map_err(Error::from),
@@ -182,7 +182,10 @@ impl Client {
             transfer_proof
         );
 
-        let _ = self.session.send_cmd(&message).await?;
+        let _ = self
+            .session
+            .send_without_listening_for_response(&message)
+            .await?;
 
         let mut actor = self.transfer_actor.lock().await;
         // First register with local actor, then reply.

--- a/src/client/transfer_actor/mod.rs
+++ b/src/client/transfer_actor/mod.rs
@@ -131,7 +131,7 @@ impl Client {
         let message = self.create_query_message(msg_contents).await?;
 
         // This is a normal response manager request. We want quorum on this for now...
-        let res = self.session.send_query(&message).await?;
+        let res = self.session.send_and_listen_for_response(&message).await?;
 
         let history = match res {
             QueryResponse::GetHistory(history) => history.map_err(Error::from),
@@ -175,7 +175,7 @@ impl Client {
 
         // This is a normal response manager request. We want quorum on this for now...
 
-        let res = self.session.send_query(&message).await?;
+        let res = self.session.send_and_listen_for_response(&message).await?;
 
         match res {
             QueryResponse::GetStoreCost(cost) => cost.map_err(Error::ErrorMessage),

--- a/src/client/transfer_actor/simulated_payouts.rs
+++ b/src/client/transfer_actor/simulated_payouts.rs
@@ -75,7 +75,10 @@ impl Client {
 
         let message = self.create_cmd_message(simluated_farming_cmd).await?;
 
-        let _ = self.session.send_cmd(&message).await?;
+        let _ = self
+            .session
+            .send_without_listening_for_response(&message)
+            .await?;
 
         // If we're getting the payout for our own actor, update it here
         info!("Applying simulated payout locally, via query for history...");

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -72,18 +72,12 @@ impl RecentSentMessages {
 
         // first remove anything older than our cache length
         if ids.len() == RECENT_SENT_MESSAGE_CACHE_LENGTH {
-            match ids.pop_front() {
-                Some(id) => {
-                    // remove oldest message
-                    let _ = messages.remove(&id);
-                }
-                None => {
-                    // nothing to do we can just add it.
-                }
+            if let Some(id) = ids.pop_front() {
+                // remove oldest message
+                let _ = messages.remove(&id);
             };
             //add new message
             let _ = messages.insert(msg_id, message);
-
             let _ = ids.push_back(msg_id);
         }
 
@@ -93,7 +87,7 @@ impl RecentSentMessages {
     pub async fn get(&self, msg_id: &MessageId) -> Option<Message> {
         let messages = self.messages.lock().await;
 
-        messages.get(msg_id).map(|msg| msg.clone())
+        messages.get(msg_id).cloned()
     }
 }
 


### PR DESCRIPTION
- adds small cache for sending messages (currently set to be 100 messages).
- add to cache on send
- remove oldest if we're over the limit
- re send messags on infra update messages received in response to an outgoing msg (after updating our session)