### PR TITLE
Rebootstrap with SectionInfo::Redirect instead of connecting to all peers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,9 @@ xor_name = "1.2.0"
   version = "~0.5.2"
 
   [dependencies.qp2p]
-  version = "~0.11.7"
+  #version = "~0.11.6"
+  git = "https://github.com/lionel1704/qp2p"
+  branch = "rebootstrap"
   features = [ "no-igd" ]
 
   [dependencies.serde]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -297,7 +297,11 @@ pub async fn attempt_bootstrap(
             Err(err) => {
                 attempts += 1;
                 if attempts < 3 {
-                    trace!("Error connecting to network! Retrying... ({})", attempts);
+                    trace!(
+                        "Error connecting to network! {:?}\nRetrying... ({})",
+                        err,
+                        attempts
+                    );
                 } else {
                     return Err(err);
                 }

--- a/src/client/register_apis.rs
+++ b/src/client/register_apis.rs
@@ -505,7 +505,7 @@ mod tests {
         assert!(register.is_public());
 
         match client.delete_register(address).await {
-            Err(Error::ErrorMessage(ErrorMessage::InvalidOperation)) => {}
+            Err(Error::ErrorMessage(ErrorMessage::InvalidOperation(_))) => {}
             Err(err) => bail!(
                 "Unexpected error returned when attempting to delete a Public Register: {}",
                 err

--- a/src/client/sequence_apis.rs
+++ b/src/client/sequence_apis.rs
@@ -1228,7 +1228,7 @@ mod tests {
 
         // Check that our data still exists.
         match client.get_sequence(address).await {
-            Err(Error::ErrorMessage(ErrorMessage::InvalidOperation)) => Ok(()),
+            Err(Error::ErrorMessage(ErrorMessage::InvalidOperation(_))) => Ok(()),
             Err(err) => Err(anyhow!(
                 "Unexpected error returned when attempting to get a Public Sequence: {}",
                 err


### PR DESCRIPTION
When SectionInfo::Redirect is called we can re-boostrap instead of connecting to all the provided peers and sending the bootstrap request.
In the testnet for a client redirect was sent 8 times which meant 8 x 7 connections which were eventually just dropped.
