### PR TITLE
fix(deps): use released version of qp2p instead of git branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ xor_name = "1.2.0"
   version = "~0.5.2"
 
   [dependencies.qp2p]
-  git = "https://github.com/lionel1704/qp2p"
-  branch = "rebootstrap"
+  version = "0.11.9"
   features = [ "no-igd" ]
 
   [dependencies.serde]


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
