### PR TITLE
fix(messaging): don't discard error responses for Blob Queries

### DIFF
--- a/src/connections/messaging.rs
+++ b/src/connections/messaging.rs
@@ -376,13 +376,6 @@ impl Session {
                         responses_discarded += 1;
                     }
                 }
-                (Ok(Some(other)), Some(_)) => {
-                    warn!(
-                        "Unexpected message in reply to query (retrying): {:?}",
-                        other
-                    );
-                    responses_discarded += 1;
-                }
                 (Ok(Some(response)), _) => {
                     debug!("QueryResponse received is: {:#?}", response);
                     break Some(response);


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
